### PR TITLE
Changing the master and slave phrasing

### DIFF
--- a/rs485/MinimalModbus-0.6/doc/conf.py
+++ b/rs485/MinimalModbus-0.6/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'minimalmodbus'

--- a/rs485/MinimalModbus-0.6/eurotherm3500.py
+++ b/rs485/MinimalModbus-0.6/eurotherm3500.py
@@ -43,7 +43,7 @@ class Eurotherm3500( minimalmodbus.Instrument ):
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -56,8 +56,8 @@ class Eurotherm3500( minimalmodbus.Instrument ):
 
     """
     
-    def __init__(self, portname, slaveaddress):
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress)
+    def __init__(self, portname, subordinateaddress):
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress)
     
     ## Process value
     

--- a/rs485/MinimalModbus-0.6/minimalmodbus.py
+++ b/rs485/MinimalModbus-0.6/minimalmodbus.py
@@ -94,16 +94,16 @@ MODE_ASCII = 'ascii'
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``COM4`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
         * mode (str): Mode selection. Can be MODE_RTU or MODE_ASCII!
 
     """
 
-    def __init__(self, port, slaveaddress, mode=MODE_RTU):
+    def __init__(self, port, subordinateaddress, mode=MODE_RTU):
         if port not in _SERIALPORTS or not _SERIALPORTS[port]:
             self.serial = _SERIALPORTS[port] = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, stopbits=STOPBITS, timeout=TIMEOUT)
         else:
@@ -127,11 +127,11 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.mode = mode
-        """Slave mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
+        """Subordinate mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
 
         New in version 0.6.
         """
@@ -167,15 +167,15 @@ class Instrument():
             )
 
     ######################################
-    ## Methods for talking to the slave ##
+    ## Methods for talking to the subordinate ##
     ######################################
 
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -190,10 +190,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -210,17 +210,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -235,7 +235,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -255,21 +255,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -293,17 +293,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -322,9 +322,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -332,8 +332,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -352,9 +352,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -365,12 +365,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -389,17 +389,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -416,13 +416,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -440,16 +440,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -469,12 +469,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -495,17 +495,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -542,11 +542,11 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770,
+        If a value of 77.0 is stored internally in the subordinate register as 770,
         then use ``numberOfDecimals=1`` which will divide the received data by 10
         before returning the value. Similarly ``numberOfDecimals=2`` will divide
         the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -644,25 +644,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -684,37 +684,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -722,7 +722,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -750,15 +750,15 @@ class Instrument():
     ##########################################
 
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -771,16 +771,16 @@ class Instrument():
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
 
         _checkFunctioncode(functioncode, None)
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
         # Build message
-        message = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
+        message = _embedPayload(self.address, self.mode, functioncode, payloadToSubordinate)
 
         # Calculate number of bytes to read
         number_of_bytes_to_read = DEFAULT_NUMBER_OF_BYTES_TO_READ
         if self.precalculate_read_size:
             try:
-                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSlave)
+                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSubordinate)
             except:
                 if self.debug:
                     template = 'MinimalModbus debug mode. Could not precalculate response size for Modbus {} mode. ' + \
@@ -791,19 +791,19 @@ class Instrument():
         response = self._communicate(message, number_of_bytes_to_read)
 
         # Extract payload
-        payloadFromSlave = _extractPayload(response, self.address, self.mode, functioncode)
-        return payloadFromSlave
+        payloadFromSubordinate = _extractPayload(response, self.address, self.mode, functioncode)
+        return payloadFromSubordinate
 
 
     def _communicate(self, message, number_of_bytes_to_read):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
             number_of_bytes_to_read (int): number of bytes to read
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -821,9 +821,9 @@ class Instrument():
 
         Timing::
 
-                                                  Request from master (Master is writing)
+                                                  Request from main (Main is writing)
                                                   |
-                                                  |       Response from slave (Master is reading)
+                                                  |       Response from subordinate (Main is reading)
                                                   |       |
             ----W----R----------------------------W-------R----------------------------------------
                      |                            |       |
@@ -915,35 +915,35 @@ class Instrument():
 ####################
 
 
-def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, mode, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * mode (str): The modbus protcol mode (rtu or ascii)
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
     The resulting message has the format:
-     * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
-     * ASCII Mode: header (:) + slaveaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
+     * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+     * ASCII Mode: header (:) + subordinateaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    The LRC or CRC is calculated from the byte string made up of slaveaddress + functioncode + payloaddata.
+    The LRC or CRC is calculated from the byte string made up of subordinateaddress + functioncode + payloaddata.
     The header, LRC/CRC, and footer are excluded from the calculation.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
 
     if mode == MODE_ASCII:
         message = _ASCII_HEADER + \
@@ -956,12 +956,12 @@ def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
     return message
 
 
-def _extractPayload(response, slaveaddress, mode, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, mode, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * mode (str): The modbus protcol mode (rtu or ascii)
         * functioncode (int): Used here for error checking only.
 
@@ -972,10 +972,10 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
     The received response should have the format:
-        RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
-        ASCII Mode: header (:) + slaveaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
+        RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+        ASCII Mode: header (:) + subordinateaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    For development purposes, this function can also be used to extract the payload from the message sent TO the slave.
+    For development purposes, this function can also be used to extract the payload from the message sent TO the subordinate.
 
     """
     BYTEPOSITION_FOR_ASCII_HEADER          = 0  # Relative to plain response
@@ -993,7 +993,7 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
 
@@ -1053,18 +1053,18 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
                 response, plainresponse)
         raise ValueError(text)
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord(response[BYTEPOSITION_FOR_SLAVEADDRESS])
 
-    if responseaddress != slaveaddress:
-        raise ValueError('Wrong return slave address: {} instead of {}. The response is: {!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError('Wrong return subordinate address: {} instead of {}. The response is: {!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord(response[BYTEPOSITION_FOR_FUNCTIONCODE])
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {} instead of {}. The response is: {!r}'.format( \
@@ -1086,13 +1086,13 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 ############################################
 
 
-def _predictResponseSize(mode, functioncode, payloadToSlave):
-    """Calculate the number of bytes that should be received from the slave.
+def _predictResponseSize(mode, functioncode, payloadToSubordinate):
+    """Calculate the number of bytes that should be received from the subordinate.
 
     Args:
      * mode (str) :
      * functioncode (int):
-     * payloadToSlave (str): The raw message that is to be sent to the slave (not hex encoded string)
+     * payloadToSubordinate (str): The raw message that is to be sent to the subordinate (not hex encoded string)
 
     Returns:
         The preducted number of bytes (int) in the response.
@@ -1117,14 +1117,14 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
     # Argument validity testing
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
-    _checkString(payloadToSlave, description='payload', minlength=MIN_PAYLOAD_LENGTH)
+    _checkString(payloadToSubordinate, description='payload', minlength=MIN_PAYLOAD_LENGTH)
 
     # Calculate payload size
     if functioncode in [5, 6, 15, 16]:
         response_payload_size = NUMBER_OF_PAYLOAD_BYTES_IN_WRITE_CONFIRMATION
 
     elif functioncode in [1, 2, 3, 4]:
-        given_size = _twoByteStringToNum(payloadToSlave[BYTERANGE_FOR_GIVEN_SIZE])
+        given_size = _twoByteStringToNum(payloadToSubordinate[BYTERANGE_FOR_GIVEN_SIZE])
         if functioncode == 1 or functioncode == 2:
             # Algorithm from MODBUS APPLICATION PROTOCOL SPECIFICATION V1.1b
             number_of_inputs = given_size
@@ -1138,7 +1138,7 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
 
     else:
         raise ValueError('Wrong functioncode: {}. The payload is: {!r}'.format( \
-            functioncode, payloadToSlave))
+            functioncode, payloadToSubordinate))
 
     # Calculate number of bytes to read
     if mode == MODE_ASCII:
@@ -1211,8 +1211,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1305,7 +1305,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1337,7 +1337,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1367,11 +1367,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1412,7 +1412,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1451,14 +1451,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1480,13 +1480,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1550,7 +1550,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -2033,11 +2033,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -2046,7 +2046,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/rs485/MinimalModbus-0.6/omegacn7500.py
+++ b/rs485/MinimalModbus-0.6/omegacn7500.py
@@ -88,7 +88,7 @@ class OmegaCN7500( minimalmodbus.Instrument ):
             * Linux: '/dev/ttyUSB0'
             * Windows: '/com3'
             
-        * slaveaddress (int): slave address in the range 1 to 247 (in decimal)
+        * subordinateaddress (int): subordinate address in the range 1 to 247 (in decimal)
 
     The controller can be used to follow predefined temperature programs, called patterns. 
     Eight patterns (numbered 0-7) are available, each having eight temperature steps (numbered 0-7).
@@ -120,8 +120,8 @@ class OmegaCN7500( minimalmodbus.Instrument ):
     
     """
     
-    def __init__(self, portname, slaveaddress):
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress)
+    def __init__(self, portname, subordinateaddress):
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress)
         self.setpoint_max = SETPOINT_MAX
         self.time_max = TIME_MAX
         

--- a/rs485/MinimalModbus-0.6/test/test_deltaDTB4824.py
+++ b/rs485/MinimalModbus-0.6/test/test_deltaDTB4824.py
@@ -45,7 +45,7 @@ Use these setting values in the temperature controller:
  * SP   1    (Decimal point position)
  * CoSH on   (ON: communication write-in enabled)
  * C-SL rtu
- * C-no 1    (Slave number)
+ * C-no 1    (Subordinate number)
  * BPS       (see the DEFAULT_BAUDRATE setting below, or the command line argument)
  * LEN  8
  * PRTY None
@@ -162,7 +162,7 @@ def main():
     text += '## Platform:       {:15}                           ##\n'.format(sys.platform)
     text += '## Port name (-D): {:15}                           ##\n'.format(instrument.serial.port)
     text += '##                                                           ##\n'
-    text += '## Slave address:  {:<15}                           ##\n'.format(instrument.address)
+    text += '## Subordinate address:  {:<15}                           ##\n'.format(instrument.address)
     text += '## Timeout:        {:0.3f} s                                   ##\n'.format(instrument.serial.timeout)
     text += '## Full file path: ' + os.path.abspath(__file__) + '\n'
     text += '###############################################################\n'
@@ -192,7 +192,7 @@ def main():
         # Should send '\x01\x06\x10\x01\x03\x20\xdd\xe2' OK!
         instrument.write_register(0x1001, 0x0320, functioncode=6)
         # Response from instrument: '\x01\x06\x10\x01\x03 \xdd\xe2' OK!
-        # Note that the slave will indicate an error if the CoSH parameter in the controller
+        # Note that the subordinate will indicate an error if the CoSH parameter in the controller
         # does not allow writing.
         # ASCII mode: Request  ':010610010320C5\r\n' 
         #             Response ':010610010320C5\r\n'

--- a/rs485/MinimalModbus-0.6/test/test_eurotherm3500.py
+++ b/rs485/MinimalModbus-0.6/test/test_eurotherm3500.py
@@ -179,8 +179,8 @@ RESPONSES['\x01\x03' + '\x01\x0c\x00\x01' + 'E\xf5']    = '\x01\x03' + '\x02\x00
 
 # get_pv_loop1: Return value 77.0
 # -----------------------------------------------------------------#
-# Message:  slave address 1, function code 3, register address 289, 1 register, CRC. 
-# Response: slave address 1, function code 3, 2 bytes, value=770, CRC=14709
+# Message:  subordinate address 1, function code 3, register address 289, 1 register, CRC. 
+# Response: subordinate address 1, function code 3, 2 bytes, value=770, CRC=14709
 RESPONSES['\x01\x03' + '\x01!\x00\x01' + '\xd5\xfc']    = '\x01\x03' + '\x02\x03\x02' + '\x39\x75'
 
 # get_pv_loop2(): Return value 19.2 

--- a/rs485/MinimalModbus-0.6/test/test_minimalmodbus.py
+++ b/rs485/MinimalModbus-0.6/test/test_minimalmodbus.py
@@ -31,16 +31,16 @@ This unittest suite uses a mock/dummy serial port from the module :mod:`dummy_se
 so it is possible to test the functionality using previously recorded communication data.
 
 With dummy responses, it is also possible to simulate errors in the communication
-from the slave. A few different types of communication errors are tested, as seen in this table.
+from the subordinate. A few different types of communication errors are tested, as seen in this table.
 
 =====================================  ===================== =================================
 Simulated response error               Tested using function Tested using Modbus function code
 =====================================  ===================== =================================
 No response                            read_bit              2
 Wrong CRC in response                  write_register        16
-Wrong slave address in response        write_register        16
+Wrong subordinate address in response        write_register        16
 Wrong function code in response        write_register        16
-Slave indicates an error               write_register        16
+Subordinate indicates an error               write_register        16
 Wrong byte count in response           read_bit              2
 Wrong register address in response     write_register        16
 Wrong number of registers in response  write_bit             15
@@ -168,13 +168,13 @@ class TestEmbedPayload(ExtendedTestCase):
     ]
 
     def testKnownValues(self):
-        for slaveaddress, functioncode, mode, inputstring, knownresult in self.knownValues:
+        for subordinateaddress, functioncode, mode, inputstring, knownresult in self.knownValues:
 
-            result = minimalmodbus._embedPayload(slaveaddress, mode, functioncode, inputstring)
+            result = minimalmodbus._embedPayload(subordinateaddress, mode, functioncode, inputstring)
             self.assertEqual(result, knownresult)
 
     def testWrongInputValue(self):
-        self.assertRaises(ValueError, minimalmodbus._embedPayload, 248, 'rtu',   16,  'ABC') # Wrong slave address
+        self.assertRaises(ValueError, minimalmodbus._embedPayload, 248, 'rtu',   16,  'ABC') # Wrong subordinate address
         self.assertRaises(ValueError, minimalmodbus._embedPayload, -1,  'rtu',   16,  'ABC')
         self.assertRaises(ValueError, minimalmodbus._embedPayload, 248, 'ascii', 16,  'ABC')
         self.assertRaises(ValueError, minimalmodbus._embedPayload, -1,  'ascii', 16,  'ABC')
@@ -206,18 +206,18 @@ class TestExtractPayload(ExtendedTestCase):
     knownValues = TestEmbedPayload.knownValues
 
     def testKnownValues(self):
-        for slaveaddress, functioncode, mode, knownresult, inputstring in self.knownValues:
-            result = minimalmodbus._extractPayload(inputstring, slaveaddress, mode, functioncode)
+        for subordinateaddress, functioncode, mode, knownresult, inputstring in self.knownValues:
+            result = minimalmodbus._extractPayload(inputstring, subordinateaddress, mode, functioncode)
             self.assertEqual(result, knownresult)
 
     def testWrongInputValue(self):
-        self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x02123X\xc3',     2,     'rtu',   2) # Wrong CRC from slave
-        self.assertRaises(ValueError, minimalmodbus._extractPayload, ':0202313233F1\r\n',    2,     'ascii', 2) # Wrong LRC from slave
-        self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x82123q\x02',     2,     'rtu',   2) # Error indication from slave
+        self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x02123X\xc3',     2,     'rtu',   2) # Wrong CRC from subordinate
+        self.assertRaises(ValueError, minimalmodbus._extractPayload, ':0202313233F1\r\n',    2,     'ascii', 2) # Wrong LRC from subordinate
+        self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x82123q\x02',     2,     'rtu',   2) # Error indication from subordinate
         self.assertRaises(ValueError, minimalmodbus._extractPayload, ':0282313233E6\r\n',    2,     'ascii', 2)
-        self.assertRaises(ValueError, minimalmodbus._extractPayload, 'ABC',                  2,     'rtu',   2) # Too short message from slave
+        self.assertRaises(ValueError, minimalmodbus._extractPayload, 'ABC',                  2,     'rtu',   2) # Too short message from subordinate
         self.assertRaises(ValueError, minimalmodbus._extractPayload, 'ABCDEFGH',             2,     'ascii', 2)
-        self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x72123B\x02',     2,     'rtu',   2) # Wrong functioncode from slave
+        self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x72123B\x02',     2,     'rtu',   2) # Wrong functioncode from subordinate
         self.assertRaises(ValueError, minimalmodbus._extractPayload, ':020431323364\r\n',    2,     'ascii', 2)
         self.assertRaises(ValueError, minimalmodbus._extractPayload, '020231323366\r\n',     2,     'ascii', 2) # Missing ASCII header
         self.assertRaises(ValueError, minimalmodbus._extractPayload, ':020231323366',        2,     'ascii', 2) # Wrong ASCII footer
@@ -226,7 +226,7 @@ class TestExtractPayload(ExtendedTestCase):
         self.assertRaises(ValueError, minimalmodbus._extractPayload, ':02023132366\r\n',     2,     'ascii', 2) # Odd number of ASCII payload characters
         
         for value in [3, 95, 128, 248, -1]:
-            self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', value, 'rtu',   2) # Wrong slave address
+            self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', value, 'rtu',   2) # Wrong subordinate address
             self.assertRaises(ValueError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', 2,     'rtu',   value) # Wrong functioncode
         
         for value in ['RTU', 'ASCII', 'asc', '', ' ']:
@@ -234,7 +234,7 @@ class TestExtractPayload(ExtendedTestCase):
         
     def testWrongInputType(self):
         for value in _NOT_INTERGERS:
-            self.assertRaises(TypeError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', value, 'rtu',   2) # Wrong slaveaddress type
+            self.assertRaises(TypeError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', value, 'rtu',   2) # Wrong subordinateaddress type
             self.assertRaises(TypeError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', value, 'ascii', 2)
             self.assertRaises(TypeError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', 2,     'rtu',   value)  # Wrong functioncode type
             self.assertRaises(TypeError, minimalmodbus._extractPayload, '\x02\x02123X\xc2', 2,     'ascii', value)
@@ -249,9 +249,9 @@ class TestSanityEmbedExtractPayload(ExtendedTestCase):
     knownValues = TestEmbedPayload.knownValues
 
     def testKnownValues(self):
-        for slaveaddress, functioncode, mode, payload, message in self.knownValues:
-            embeddedResult  = minimalmodbus._embedPayload(slaveaddress, mode, functioncode, payload)
-            extractedResult = minimalmodbus._extractPayload(embeddedResult, slaveaddress, mode, functioncode)
+        for subordinateaddress, functioncode, mode, payload, message in self.knownValues:
+            embeddedResult  = minimalmodbus._embedPayload(subordinateaddress, mode, functioncode, payload)
+            extractedResult = minimalmodbus._extractPayload(embeddedResult, subordinateaddress, mode, functioncode)
             self.assertEqual(extractedResult, payload)
             
     def testRange(self):
@@ -295,31 +295,31 @@ class TestPredictResponseSize(ExtendedTestCase):
     ]
     
     def testKnownValues(self):
-        for mode, functioncode, payloadToSlave, knownvalue in self.knownValues:
-            resultvalue = minimalmodbus._predictResponseSize(mode, functioncode, payloadToSlave)
+        for mode, functioncode, payloadToSubordinate, knownvalue in self.knownValues:
+            resultvalue = minimalmodbus._predictResponseSize(mode, functioncode, payloadToSubordinate)
             self.assertEqual(resultvalue, knownvalue)
 
     def testRecordedRtuMessages(self):            
         ## Use the dictionary where the key is the 'message', and the item is the 'response'
         for message in GOOD_RTU_RESPONSES:
-            slaveaddress = ord(message[0])
+            subordinateaddress = ord(message[0])
             functioncode = ord(message[1])
-            payloadToSlave = minimalmodbus._extractPayload(message, slaveaddress, 'rtu', functioncode)
-            result = minimalmodbus._predictResponseSize('rtu', functioncode, payloadToSlave)
+            payloadToSubordinate = minimalmodbus._extractPayload(message, subordinateaddress, 'rtu', functioncode)
+            result = minimalmodbus._predictResponseSize('rtu', functioncode, payloadToSubordinate)
             
-            responseFromSlave = GOOD_RTU_RESPONSES[message]
-            self.assertEqual(result, len(responseFromSlave))
+            responseFromSubordinate = GOOD_RTU_RESPONSES[message]
+            self.assertEqual(result, len(responseFromSubordinate))
 
     def testRecordedAsciiMessages(self):    
         ## Use the dictionary where the key is the 'message', and the item is the 'response'
         for message in GOOD_ASCII_RESPONSES:
-            slaveaddress = int(message[1:3])
+            subordinateaddress = int(message[1:3])
             functioncode = int(message[3:5])
-            payloadToSlave = minimalmodbus._extractPayload(message, slaveaddress, 'ascii', functioncode)
-            result = minimalmodbus._predictResponseSize('ascii', functioncode, payloadToSlave)
+            payloadToSubordinate = minimalmodbus._extractPayload(message, subordinateaddress, 'ascii', functioncode)
+            result = minimalmodbus._predictResponseSize('ascii', functioncode, payloadToSubordinate)
             
-            responseFromSlave = GOOD_ASCII_RESPONSES[message]
-            self.assertEqual(result, len(responseFromSlave))
+            responseFromSubordinate = GOOD_ASCII_RESPONSES[message]
+            self.assertEqual(result, len(responseFromSubordinate))
      
     def testWrongInputValue(self):
         self.assertRaises(ValueError, minimalmodbus._predictResponseSize, 'asciiii',    6,      'ABCD') # Wrong mode
@@ -1243,21 +1243,21 @@ class TestCheckFunctioncode(ExtendedTestCase):
         self.assertRaises(TypeError,  minimalmodbus._checkFunctioncode, 4, [4.0, 5])
 
 
-class TestCheckSlaveaddress(ExtendedTestCase):
+class TestCheckSubordinateaddress(ExtendedTestCase):
 
     def testKnownValues(self):
-        minimalmodbus._checkSlaveaddress( 0 )
-        minimalmodbus._checkSlaveaddress( 1 )
-        minimalmodbus._checkSlaveaddress( 10 )
-        minimalmodbus._checkSlaveaddress( 247 )
+        minimalmodbus._checkSubordinateaddress( 0 )
+        minimalmodbus._checkSubordinateaddress( 1 )
+        minimalmodbus._checkSubordinateaddress( 10 )
+        minimalmodbus._checkSubordinateaddress( 247 )
 
     def testWrongValues(self):
-        self.assertRaises(ValueError, minimalmodbus._checkSlaveaddress, -1)
-        self.assertRaises(ValueError, minimalmodbus._checkSlaveaddress, 248)
+        self.assertRaises(ValueError, minimalmodbus._checkSubordinateaddress, -1)
+        self.assertRaises(ValueError, minimalmodbus._checkSubordinateaddress, 248)
 
     def testNotIntegerInput(self):
         for value in _NOT_INTERGERS:
-            self.assertRaises(TypeError, minimalmodbus._checkSlaveaddress, value)
+            self.assertRaises(TypeError, minimalmodbus._checkSubordinateaddress, value)
 
 
 class TestCheckMode(ExtendedTestCase):
@@ -1554,7 +1554,7 @@ class TestDummyCommunication(ExtendedTestCase):
 
         # Initialize a (dummy) instrument
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1, minimalmodbus.MODE_RTU) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1, minimalmodbus.MODE_RTU) # port name, subordinate address (in decimal)
         self.instrument.debug = False
 
 
@@ -1580,10 +1580,10 @@ class TestDummyCommunication(ExtendedTestCase):
             self.assertRaises(TypeError, self.instrument.read_bit, 62,   value)
 
     def testReadBitWithWrongByteCountResponse(self):
-        self.assertRaises(ValueError, self.instrument.read_bit, 63) # Functioncode 2. Slave gives wrong byte count.
+        self.assertRaises(ValueError, self.instrument.read_bit, 63) # Functioncode 2. Subordinate gives wrong byte count.
 
     def testReadBitWithNoResponse(self):
-        self.assertRaises(IOError, self.instrument.read_bit, 64) # Functioncode 2. Slave gives no response.
+        self.assertRaises(IOError, self.instrument.read_bit, 64) # Functioncode 2. Subordinate gives no response.
 
 
     ## Write bit ##
@@ -1613,10 +1613,10 @@ class TestDummyCommunication(ExtendedTestCase):
             self.assertRaises(TypeError, self.instrument.write_bit, 71,    1,     value)
 
     def testWriteBitWithWrongRegisternumbersResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_bit, 73, 1, functioncode=15) # Slave gives wrong number of registers
+        self.assertRaises(ValueError, self.instrument.write_bit, 73, 1, functioncode=15) # Subordinate gives wrong number of registers
 
     def testWriteBitWithWrongWritedataResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_bit, 74, 1) # Slave gives wrong write data
+        self.assertRaises(ValueError, self.instrument.write_bit, 74, 1) # Subordinate gives wrong write data
 
 
     ## Read register ##
@@ -1685,29 +1685,29 @@ class TestDummyCommunication(ExtendedTestCase):
             self.assertRaises(TypeError, self.instrument.write_register, 35,    20,    functioncode = value)
 
     def testWriteRegisterWithWrongCrcResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_register, 51, 99) # Slave gives wrong CRC
+        self.assertRaises(ValueError, self.instrument.write_register, 51, 99) # Subordinate gives wrong CRC
         
     def testWriteRegisterSuppressErrorMessageAtWrongCRC(self):
         try:
-            self.instrument.write_register(51, 99) # Slave gives wrong CRC
+            self.instrument.write_register(51, 99) # Subordinate gives wrong CRC
         except ValueError:
             minimalmodbus._print_out('Minimalmodbus: An error was suppressed.')
 
-    def testWriteRegisterWithWrongSlaveaddressResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_register, 54, 99) # Slave gives wrong slaveaddress
+    def testWriteRegisterWithWrongSubordinateaddressResponse(self):
+        self.assertRaises(ValueError, self.instrument.write_register, 54, 99) # Subordinate gives wrong subordinateaddress
 
     def testWriteRegisterWithWrongFunctioncodeResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_register, 55, 99) # Slave gives wrong functioncode
-        self.assertRaises(ValueError, self.instrument.write_register, 56, 99) # Slave indicates an error
+        self.assertRaises(ValueError, self.instrument.write_register, 55, 99) # Subordinate gives wrong functioncode
+        self.assertRaises(ValueError, self.instrument.write_register, 56, 99) # Subordinate indicates an error
 
     def testWriteRegisterWithWrongRegisteraddressResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_register, 53, 99) # Slave gives wrong registeraddress
+        self.assertRaises(ValueError, self.instrument.write_register, 53, 99) # Subordinate gives wrong registeraddress
 
     def testWriteRegisterWithWrongRegisternumbersResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_register, 52, 99) # Slave gives wrong number of registers
+        self.assertRaises(ValueError, self.instrument.write_register, 52, 99) # Subordinate gives wrong number of registers
 
     def testWriteRegisterWithWrongWritedataResponse(self):
-        self.assertRaises(ValueError, self.instrument.write_register, 55, 99, functioncode = 6) # Functioncode 6. Slave gives wrong write data.
+        self.assertRaises(ValueError, self.instrument.write_register, 55, 99, functioncode = 6) # Functioncode 6. Subordinate gives wrong write data.
 
 
     ## Read Long ##
@@ -1743,9 +1743,9 @@ class TestDummyCommunication(ExtendedTestCase):
     def testWriteLongWrongValue(self):
         self.assertRaises(ValueError, self.instrument.write_long, -1,    5) # Wrong register address
         self.assertRaises(ValueError, self.instrument.write_long, 65536, 5)
-        self.assertRaises(ValueError, self.instrument.write_long, 102,   888888888888888888888)  # Wrong value to write to slave
+        self.assertRaises(ValueError, self.instrument.write_long, 102,   888888888888888888888)  # Wrong value to write to subordinate
         if _runTestsForNewVersion:  # For Python2.6 compatibility
-            self.assertRaises(ValueError, self.instrument.write_long, 102,   -5, signed=False)  # Wrong value to write to slave
+            self.assertRaises(ValueError, self.instrument.write_long, 102,   -5, signed=False)  # Wrong value to write to subordinate
 
     def testWriteLongWrongType(self):
         for value in _NOT_INTERGERS:
@@ -2003,14 +2003,14 @@ class TestDummyCommunication(ExtendedTestCase):
     def testPerformcommandKnownResponse(self):
         self.assertEqual( self.instrument._performCommand(16, 'TESTCOMMAND'), 'TESTCOMMANDRESPONSE')
         self.assertEqual( self.instrument._performCommand(75, 'TESTCOMMAND2'), 'TESTCOMMANDRESPONSE2')
-        self.assertEqual( self.instrument._performCommand(2, '\x00\x3d\x00\x01'), '\x01\x01' ) # Read bit register 61 on slave 1 using function code 2.
+        self.assertEqual( self.instrument._performCommand(2, '\x00\x3d\x00\x01'), '\x01\x01' ) # Read bit register 61 on subordinate 1 using function code 2.
 
-    def testPerformcommandWrongSlaveResponse(self):
-        self.assertRaises(ValueError, self.instrument._performCommand, 1,  'TESTCOMMAND') # Wrong slave address in response
+    def testPerformcommandWrongSubordinateResponse(self):
+        self.assertRaises(ValueError, self.instrument._performCommand, 1,  'TESTCOMMAND') # Wrong subordinate address in response
         self.assertRaises(ValueError, self.instrument._performCommand, 2,  'TESTCOMMAND') # Wrong function code in response
         self.assertRaises(ValueError, self.instrument._performCommand, 3,  'TESTCOMMAND') # Wrong crc in response
-        self.assertRaises(ValueError, self.instrument._performCommand, 4,  'TESTCOMMAND') # Too short response message from slave
-        self.assertRaises(ValueError, self.instrument._performCommand, 5,  'TESTCOMMAND') # Error indication from slave
+        self.assertRaises(ValueError, self.instrument._performCommand, 4,  'TESTCOMMAND') # Too short response message from subordinate
+        self.assertRaises(ValueError, self.instrument._performCommand, 5,  'TESTCOMMAND') # Error indication from subordinate
         
     def testPerformcommandWrongInputValue(self):
         self.assertRaises(ValueError, self.instrument._performCommand, -1,  'TESTCOMMAND') # Wrong function code
@@ -2073,7 +2073,7 @@ class TestDummyCommunication(ExtendedTestCase):
         del(self.instrument)
 
 
-class TestDummyCommunicationOmegaSlave1(ExtendedTestCase):
+class TestDummyCommunicationOmegaSubordinate1(ExtendedTestCase):
 
     def setUp(self):
         dummy_serial.VERBOSE = False
@@ -2081,7 +2081,7 @@ class TestDummyCommunicationOmegaSlave1(ExtendedTestCase):
         dummy_serial.DEFAULT_RESPONSE = 'NotFoundInResponseDictionary'
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, subordinate address (in decimal)
 
     def testReadBit(self):
         self.assertEqual( self.instrument.read_bit(2068), 1 )
@@ -2102,7 +2102,7 @@ class TestDummyCommunicationOmegaSlave1(ExtendedTestCase):
         del(self.instrument)
 
 
-class TestDummyCommunicationOmegaSlave10(ExtendedTestCase):
+class TestDummyCommunicationOmegaSubordinate10(ExtendedTestCase):
 
     def setUp(self):
         dummy_serial.VERBOSE = False
@@ -2110,7 +2110,7 @@ class TestDummyCommunicationOmegaSlave10(ExtendedTestCase):
         dummy_serial.DEFAULT_RESPONSE = 'NotFoundInResponseDictionary'
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 10) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 10) # port name, subordinate address (in decimal)
 
     def testReadBit(self):
         self.assertEqual( self.instrument.read_bit(2068), 1 )
@@ -2141,7 +2141,7 @@ class TestDummyCommunicationDTB4824_RTU(ExtendedTestCase):
         dummy_serial.DEFAULT_RESPONSE = 'NotFoundInResponseDictionary'
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 7) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 7) # port name, subordinate address (in decimal)
     
     def testReadBit(self):
         self.assertEqual( self.instrument.read_bit(0x0800), 0) # LED AT
@@ -2189,7 +2189,7 @@ class TestDummyCommunicationDTB4824_ASCII(ExtendedTestCase):
         dummy_serial.DEFAULT_RESPONSE = 'NotFoundInResponseDictionary'
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 7, 'ascii') # port name, slave address (in decimal), mode
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 7, 'ascii') # port name, subordinate address (in decimal), mode
     
     def testReadBit(self):
         self.assertEqual( self.instrument.read_bit(0x0800), 0) # LED AT
@@ -2238,7 +2238,7 @@ class TestDummyCommunicationWithPortClosure(ExtendedTestCase):
 
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = True # Mimic a WindowsXP serial port
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, subordinate address (in decimal)
 
     def testReadRegisterSeveralTimes(self):
         self.assertEqual( self.instrument.read_register(289), 770 )
@@ -2272,7 +2272,7 @@ class TestVerboseDummyCommunicationWithPortClosure(ExtendedTestCase):
 
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = True # Mimic a WindowsXP serial port
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, subordinate address (in decimal)
 
     def testReadRegister(self):
         self.assertEqual( self.instrument.read_register(289), 770 )
@@ -2295,7 +2295,7 @@ class TestDummyCommunicationDebugmode(ExtendedTestCase):
 
         minimalmodbus.serial.Serial = dummy_serial.Serial
         minimalmodbus.CLOSE_PORT_AFTER_EACH_CALL = False
-        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, slave address (in decimal)
+        self.instrument = minimalmodbus.Instrument('DUMMYPORTNAME', 1) # port name, subordinate address (in decimal)
         self.instrument.debug = True
 
     def testReadRegister(self):
@@ -2324,325 +2324,325 @@ from the dummy serial port.
 
 #                ##  READ BIT  ##
 
-# Read bit register 61 on slave 1 using function code 2. Also for testing _performCommand() #
+# Read bit register 61 on subordinate 1 using function code 2. Also for testing _performCommand() #
 # ----------------------------------------------------------------------------------------- #
-# Message:  Slave address 1, function code 2. Register address 61, 1 coil. CRC.
-# Response: Slave address 1, function code 2. 1 byte, value=1. CRC.
+# Message:  Subordinate address 1, function code 2. Register address 61, 1 coil. CRC.
+# Response: Subordinate address 1, function code 2. 1 byte, value=1. CRC.
 GOOD_RTU_RESPONSES['\x01\x02' + '\x00\x3d\x00\x01' + '(\x06'] = '\x01\x02' + '\x01\x01' + '`H'
 
-# Read bit register 62 on slave 1 using function code 1 #
+# Read bit register 62 on subordinate 1 using function code 1 #
 # ----------------------------------------------------- #
-# Message:  Slave address 1, function code 1. Register address 62, 1 coil. CRC.
-# Response: Slave address 1, function code 1. 1 byte, value=0. CRC.
+# Message:  Subordinate address 1, function code 1. Register address 62, 1 coil. CRC.
+# Response: Subordinate address 1, function code 1. 1 byte, value=0. CRC.
 GOOD_RTU_RESPONSES['\x01\x01' + '\x00\x3e\x00\x01' + '\x9c\x06'] = '\x01\x01' + '\x01\x00' + 'Q\x88'
 
-# Read bit register 63 on slave 1 using function code 2, slave gives wrong byte count #
+# Read bit register 63 on subordinate 1 using function code 2, subordinate gives wrong byte count #
 # ----------------------------------------------------------------------------------- #
-# Message:  Slave address 1, function code 2. Register address 63, 1 coil. CRC.
-# Response: Slave address 1, function code 2. 2 bytes (wrong), value=1. CRC.
+# Message:  Subordinate address 1, function code 2. Register address 63, 1 coil. CRC.
+# Response: Subordinate address 1, function code 2. 2 bytes (wrong), value=1. CRC.
 WRONG_RTU_RESPONSES['\x01\x02' + '\x00\x3f\x00\x01' + '\x89\xc6'] = '\x01\x02' + '\x02\x01' + '`\xb8'
 
-# Read bit register 64 on slave 1 using function code 2, slave gives no response #
+# Read bit register 64 on subordinate 1 using function code 2, subordinate gives no response #
 # ------------------------------------------------------------------------------ #
-# Message:  Slave address 1, function code 2. Register address 64, 1 coil. CRC.
+# Message:  Subordinate address 1, function code 2. Register address 64, 1 coil. CRC.
 # Response: (empty string)
 WRONG_RTU_RESPONSES['\x01\x02' + '\x00\x40\x00\x01' + '\xb8\x1e'] = ''
 
 
 #                ##  WRITE BIT  ##
 
-# Write bit register 71 on slave 1 using function code 5 #
+# Write bit register 71 on subordinate 1 using function code 5 #
 # ------------------------------------------------------ #
-# Message:  Slave address 1, function code 5. Register address 71, value 1 (FF00). CRC.
-# Response: Slave address 1, function code 5. Register address 71, value 1 (FF00). CRC.
+# Message:  Subordinate address 1, function code 5. Register address 71, value 1 (FF00). CRC.
+# Response: Subordinate address 1, function code 5. Register address 71, value 1 (FF00). CRC.
 GOOD_RTU_RESPONSES['\x01\x05' + '\x00\x47\xff\x00' + '</'] = '\x01\x05' + '\x00\x47\xff\x00' + '</'
 
-# Write bit register 72 on slave 1 using function code 15 #
+# Write bit register 72 on subordinate 1 using function code 15 #
 # ------------------------------------------------------ #
-# Message:  Slave address 1, function code 15. Register address 72, 1 bit, 1 byte, value 1 (0100). CRC.
-# Response: Slave address 1, function code 15. Register address 72, 1 bit. CRC.
+# Message:  Subordinate address 1, function code 15. Register address 72, 1 bit, 1 byte, value 1 (0100). CRC.
+# Response: Subordinate address 1, function code 15. Register address 72, 1 bit. CRC.
 GOOD_RTU_RESPONSES['\x01\x0f' + '\x00\x48\x00\x01\x01\x01' + '\x0fY'] = '\x01\x0f' + '\x00\x48\x00\x01' + '\x14\x1d'
 
-# Write bit register 73 on slave 1 using function code 15, slave gives wrong number of registers #
+# Write bit register 73 on subordinate 1 using function code 15, subordinate gives wrong number of registers #
 # ---------------------------------------------------------------------------------------------- #
-# Message:  Slave address 1, function code 15. Register address 73, 1 bit, 1 byte, value 1 (0100). CRC.
-# Response: Slave address 1, function code 15. Register address 73, 2 bits (wrong). CRC.
+# Message:  Subordinate address 1, function code 15. Register address 73, 1 bit, 1 byte, value 1 (0100). CRC.
+# Response: Subordinate address 1, function code 15. Register address 73, 2 bits (wrong). CRC.
 WRONG_RTU_RESPONSES['\x01\x0f' + '\x00\x49\x00\x01\x01\x01' + '2\x99'] = '\x01\x0f' + '\x00\x49\x00\x02' + '\x05\xdc'
 
-# Write bit register 74 on slave 1 using function code 5, slave gives wrong write data #
+# Write bit register 74 on subordinate 1 using function code 5, subordinate gives wrong write data #
 # ------------------------------------------------------------------------------------ #
-# Message:  Slave address 1, function code 5. Register address 74, value 1 (FF00). CRC.
-# Response: Slave address 1, function code 5. Register address 74, value 0 (0000, wrong). CRC.
+# Message:  Subordinate address 1, function code 5. Register address 74, value 1 (FF00). CRC.
+# Response: Subordinate address 1, function code 5. Register address 74, value 0 (0000, wrong). CRC.
 WRONG_RTU_RESPONSES['\x01\x05' + '\x00\x4a\xff\x00' + '\xad\xec'] = '\x01\x05' + '\x00\x47\x00\x00' + '}\xdf'
 
 
 #                ##  READ REGISTER  ##
 
-# Read register 289 on slave 1 using function code 3 #
+# Read register 289 on subordinate 1 using function code 3 #
 # ---------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 289, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes, value=770. CRC=14709.
+# Message:  Subordinate address 1, function code 3. Register address 289, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes, value=770. CRC=14709.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x01!\x00\x01' + '\xd5\xfc'] = '\x01\x03' + '\x02\x03\x02' + '\x39\x75'
 
-# Read register 5 on slave 1 using function code 3 #
+# Read register 5 on subordinate 1 using function code 3 #
 # ---------------------------------------------------#
-# Message: Slave address 1, function code 3. Register address 289, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes, value=184. CRC
+# Message: Subordinate address 1, function code 3. Register address 289, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes, value=184. CRC
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00\x05\x00\x01' + '\x94\x0b'] = '\x01\x03' + '\x02\x00\xb8' + '\xb86'
 
-# Read register 14 on slave 1 using function code 4 #
+# Read register 14 on subordinate 1 using function code 4 #
 # --------------------------------------------------#
-# Message:  Slave address 1, function code 4. Register address 14, 1 register. CRC.
-# Response: Slave address 1, function code 4. 2 bytes, value=880. CRC.
+# Message:  Subordinate address 1, function code 4. Register address 14, 1 register. CRC.
+# Response: Subordinate address 1, function code 4. 2 bytes, value=880. CRC.
 GOOD_RTU_RESPONSES['\x01\x04' + '\x00\x0e\x00\x01' + 'P\t'] = '\x01\x04' + '\x02\x03\x70' + '\xb8$'
 
-# Read register 101 on slave 1 using function code 3 #
+# Read register 101 on subordinate 1 using function code 3 #
 # ---------------------------------------------------#
-# Message: Slave address 1, function code 3. Register address 101, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes, value=-5 or 65531 (depending on interpretation). CRC
+# Message: Subordinate address 1, function code 3. Register address 101, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes, value=-5 or 65531 (depending on interpretation). CRC
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00e\x00\x01' + '\x94\x15'] = '\x01\x03' + '\x02\xff\xfb' + '\xb87'
 
-# Read register 201 on slave 1 using function code 3 #
+# Read register 201 on subordinate 1 using function code 3 #
 # ---------------------------------------------------#
-# Message: Slave address 1, function code 3. Register address 201, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes, value=9. CRC
+# Message: Subordinate address 1, function code 3. Register address 201, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes, value=9. CRC
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00\xc9\x00\x01' + 'T4'] = '\x01\x03' + '\x02\x00\x09' + 'xB'
 
-# Read register 202 on slave 1 using function code 3. Too long response #
+# Read register 202 on subordinate 1 using function code 3. Too long response #
 # ----------------------------------------------------------------------#
-# Message: Slave address 1, function code 3. Register address 202, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes (wrong!), value=9. CRC
+# Message: Subordinate address 1, function code 3. Register address 202, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes (wrong!), value=9. CRC
 WRONG_RTU_RESPONSES['\x01\x03' + '\x00\xca\x00\x01' + '\xa44'] = '\x01\x03' + '\x02\x00\x00\x09' + '\x84t'
 
-# Read register 203 on slave 1 using function code 3. Too short response #
+# Read register 203 on subordinate 1 using function code 3. Too short response #
 # ----------------------------------------------------------------------#
-# Message: Slave address 1, function code 3. Register address 203, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes (wrong!), value=9. CRC
+# Message: Subordinate address 1, function code 3. Register address 203, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes (wrong!), value=9. CRC
 WRONG_RTU_RESPONSES['\x01\x03' + '\x00\xcb\x00\x01' + '\xf5\xf4'] = '\x01\x03' + '\x02\x09' + '0\xbe'
 
 
 #                ##  WRITE REGISTER  ##
 
-# Write value 50 in register 24 on slave 1 using function code 16 #
+# Write value 50 in register 24 on subordinate 1 using function code 16 #
 # ----------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 24, 1 register, 2 bytes, value=50. CRC.
-# Response: Slave address 1, function code 16. Register address 24, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 24, 1 register, 2 bytes, value=50. CRC.
+# Response: Subordinate address 1, function code 16. Register address 24, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00\x18\x00\x01\x02\x002' + '$]'] = '\x01\x10' + '\x00\x18\x00\x01' + '\x81\xce'
 
-# Write value 20 in register 35 on slave 1 using function code 16 #
+# Write value 20 in register 35 on subordinate 1 using function code 16 #
 # ----------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 35, 1 register, 2 bytes, value=20. CRC.
-# Response: Slave address 1, function code 16. Register address 35, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 35, 1 register, 2 bytes, value=20. CRC.
+# Response: Subordinate address 1, function code 16. Register address 35, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00#\x00\x01' + '\x02\x00\x14' + '\xa1\x0c'] = '\x01\x10' + '\x00#\x00\x01' + '\xf0\x03'
 
-# Write value 88 in register 45 on slave 1 using function code 6 #
+# Write value 88 in register 45 on subordinate 1 using function code 6 #
 # ---------------------------------------------------------------#
-# Message:  Slave address 1, function code 6. Register address 45, value=88. CRC.
-# Response: Slave address 1, function code 6. Register address 45, value=88. CRC.
+# Message:  Subordinate address 1, function code 6. Register address 45, value=88. CRC.
+# Response: Subordinate address 1, function code 6. Register address 45, value=88. CRC.
 GOOD_RTU_RESPONSES['\x01\x06' + '\x00\x2d\x00\x58' + '\x189'] = '\x01\x06' + '\x00\x2d\x00\x58' + '\x189'
 
-# Write value 5 in register 101 on slave 1 using function code 16 #
+# Write value 5 in register 101 on subordinate 1 using function code 16 #
 # ----------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 101, 1 register, 2 bytes, value=5. CRC.
-# Response: Slave address 1, function code 16. Register address 101, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 101, 1 register, 2 bytes, value=5. CRC.
+# Response: Subordinate address 1, function code 16. Register address 101, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00e\x00\x01\x02\x00\x05' + 'o\xa6'] = '\x01\x10' + '\x00e\x00\x01' + '\x11\xd6'
 
-# Write value 50 in register 101 on slave 1 using function code 16 #
+# Write value 50 in register 101 on subordinate 1 using function code 16 #
 # ----------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 101, 1 register, 2 bytes, value=5. CRC.
-# Response: Slave address 1, function code 16. Register address 101, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 101, 1 register, 2 bytes, value=5. CRC.
+# Response: Subordinate address 1, function code 16. Register address 101, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00e\x00\x01\x02\x002' + '.p'] = '\x01\x10' + '\x00e\x00\x01' + '\x11\xd6'
 
-# Write value -5 in register 101 on slave 1 using function code 16 #
+# Write value -5 in register 101 on subordinate 1 using function code 16 #
 # ----------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 101, 1 register, 2 bytes, value=-5. CRC.
-# Response: Slave address 1, function code 16. Register address 101, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 101, 1 register, 2 bytes, value=-5. CRC.
+# Response: Subordinate address 1, function code 16. Register address 101, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00e\x00\x01\x02\xff\xfb' + '\xaf\xd6'] = '\x01\x10' + '\x00e\x00\x01' + '\x11\xd6'
 
-# Write value -50 in register 101 on slave 1 using function code 16 #
+# Write value -50 in register 101 on subordinate 1 using function code 16 #
 # ----------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 101, 1 register, 2 bytes, value=-50. CRC.
-# Response: Slave address 1, function code 16. Register address 101, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 101, 1 register, 2 bytes, value=-50. CRC.
+# Response: Subordinate address 1, function code 16. Register address 101, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00e\x00\x01\x02\xff\xce' + 'o\xc1'] = '\x01\x10' + '\x00e\x00\x01' + '\x11\xd6'
 
-# Write value 99 in register 51 on slave 1 using function code 16, slave gives wrong CRC #
+# Write value 99 in register 51 on subordinate 1 using function code 16, subordinate gives wrong CRC #
 # ---------------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 51, 1 register, 2 bytes, value=99. CRC.
-# Response: Slave address 1, function code 16. Register address 51, 1 register. Wrong CRC.
+# Message:  Subordinate address 1, function code 16. Register address 51, 1 register, 2 bytes, value=99. CRC.
+# Response: Subordinate address 1, function code 16. Register address 51, 1 register. Wrong CRC.
 WRONG_RTU_RESPONSES['\x01\x10' + '\x00\x33\x00\x01' + '\x02\x00\x63' + '\xe3\xba'] = '\x01\x10' + '\x00\x33\x00\x01' + 'AB'
 
-# Write value 99 in register 52 on slave 1 using function code 16, slave gives wrong number of registers #
+# Write value 99 in register 52 on subordinate 1 using function code 16, subordinate gives wrong number of registers #
 # -------------------------------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 52, 1 register, 2 bytes, value=99. CRC.
-# Response: Slave address 1, function code 16. Register address 52, 2 registers (wrong). CRC.
+# Message:  Subordinate address 1, function code 16. Register address 52, 1 register, 2 bytes, value=99. CRC.
+# Response: Subordinate address 1, function code 16. Register address 52, 2 registers (wrong). CRC.
 WRONG_RTU_RESPONSES['\x01\x10' + '\x00\x34\x00\x01' + '\x02\x00\x63' + '\xe2\r'] = '\x01\x10' + '\x00\x34\x00\x02' + '\x00\x06'
 
-# Write value 99 in register 53 on slave 1 using function code 16, slave gives wrong register address #
+# Write value 99 in register 53 on subordinate 1 using function code 16, subordinate gives wrong register address #
 # ----------------------------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 53, 1 register, 2 bytes, value=99. CRC.
-# Response: Slave address 1, function code 16. Register address 54 (wrong), 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 53, 1 register, 2 bytes, value=99. CRC.
+# Response: Subordinate address 1, function code 16. Register address 54 (wrong), 1 register. CRC.
 WRONG_RTU_RESPONSES['\x01\x10' + '\x00\x35\x00\x01' + '\x02\x00\x63' + '\xe3\xdc'] = '\x01\x10' + '\x00\x36\x00\x01' + '\xe1\xc7'
 
-# Write value 99 in register 54 on slave 1 using function code 16, slave gives wrong slave address #
+# Write value 99 in register 54 on subordinate 1 using function code 16, subordinate gives wrong subordinate address #
 # ------------------------------------------------------------------------------------------------ #
-# Message:  Slave address 1, function code 16. Register address 54, 1 register, 2 bytes, value=99. CRC.
-# Response: Slave address 2 (wrong), function code 16. Register address 54, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 54, 1 register, 2 bytes, value=99. CRC.
+# Response: Subordinate address 2 (wrong), function code 16. Register address 54, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00\x36\x00\x01' + '\x02\x00\x63' + '\xe3\xef'] = '\x02\x10' + '\x00\x36\x00\x01' + '\xe1\xf4'
 
-# Write value 99 in register 55 on slave 1 using function code 16, slave gives wrong functioncode #
+# Write value 99 in register 55 on subordinate 1 using function code 16, subordinate gives wrong functioncode #
 # ----------------------------------------------------------------------------------------------- #
-# Message:  Slave address 1, function code 16. Register address 55, 1 register, 2 bytes, value=99. CRC.
-# Response: Slave address 1, function code 6 (wrong). Register address 55, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 55, 1 register, 2 bytes, value=99. CRC.
+# Response: Subordinate address 1, function code 6 (wrong). Register address 55, 1 register. CRC.
 WRONG_RTU_RESPONSES['\x01\x10' + '\x00\x37\x00\x01' + '\x02\x00\x63' + '\xe2>'] = '\x01\x06' + '\x00\x37\x00\x01' + '\xf9\xc4'
 
-# Write value 99 in register 56 on slave 1 using function code 16, slave gives wrong functioncode (indicates an error) #
+# Write value 99 in register 56 on subordinate 1 using function code 16, subordinate gives wrong functioncode (indicates an error) #
 # -------------------------------------------------------------------------------------------------------------------- #
-# Message:  Slave address 1, function code 16. Register address 56, 1 register, 2 bytes, value=99. CRC.
-# Response: Slave address 1, function code 144 (wrong). Register address 56, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 56, 1 register, 2 bytes, value=99. CRC.
+# Response: Subordinate address 1, function code 144 (wrong). Register address 56, 1 register. CRC.
 WRONG_RTU_RESPONSES['\x01\x10' + '\x00\x38\x00\x01' + '\x02\x00\x63' + '\xe2\xc1'] = '\x01\x90' + '\x00\x38\x00\x01' + '\x81\xda'
 
-# Write value 99 in register 55 on slave 1 using function code 6, slave gives wrong write data #
+# Write value 99 in register 55 on subordinate 1 using function code 6, subordinate gives wrong write data #
 # -------------------------------------------------------------------------------------------- #
-# Message:  Slave address 1, function code 6. Register address 55, value=99. CRC.
-# Response: Slave address 1, function code 6. Register address 55, value=98 (wrong). CRC.
+# Message:  Subordinate address 1, function code 6. Register address 55, value=99. CRC.
+# Response: Subordinate address 1, function code 6. Register address 55, value=98 (wrong). CRC.
 WRONG_RTU_RESPONSES['\x01\x06' + '\x00\x37\x00\x63' + 'x-'] = '\x01\x06' + '\x00\x37\x00\x62' + '\xb9\xed'
 
 
 #                ##  READ LONG ##
 
-# Read long (2 registers, starting at 102) on slave 1 using function code 3 #
+# Read long (2 registers, starting at 102) on subordinate 1 using function code 3 #
 # --------------------------------------------------------------------------#
-# Message: Slave address 1, function code 3. Register address 289, 2 registers. CRC.
-# Response: Slave address 1, function code 3. 4 bytes, value=-1 or 4294967295 (depending on interpretation). CRC
+# Message: Subordinate address 1, function code 3. Register address 289, 2 registers. CRC.
+# Response: Subordinate address 1, function code 3. 4 bytes, value=-1 or 4294967295 (depending on interpretation). CRC
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00f\x00\x02' + '$\x14'] = '\x01\x03' + '\x04\xff\xff\xff\xff' + '\xfb\xa7'
 
 
 #                ##  WRITE LONG ##
 
-# Write long (2 registers, starting at 102) on slave 1 using function code 16, with value 5. #
+# Write long (2 registers, starting at 102) on subordinate 1 using function code 16, with value 5. #
 # -------------------------------------------------------------------------------------------#
-# Message: Slave address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=5. CRC.
-# Response: Slave address 1, function code 16. Register address 102, 2 registers. CRC
+# Message: Subordinate address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=5. CRC.
+# Response: Subordinate address 1, function code 16. Register address 102, 2 registers. CRC
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00f\x00\x02\x04\x00\x00\x00\x05' + '\xb5\xae'] = '\x01\x10' + '\x00f\x00\x02' + '\xa1\xd7'
 
-# Write long (2 registers, starting at 102) on slave 1 using function code 16, with value -5. #
+# Write long (2 registers, starting at 102) on subordinate 1 using function code 16, with value -5. #
 # --------------------------------------------------------------------------------------------#
-# Message: Slave address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=-5. CRC.
-# Response: Slave address 1, function code 16. Register address 102, 2 registers. CRC
+# Message: Subordinate address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=-5. CRC.
+# Response: Subordinate address 1, function code 16. Register address 102, 2 registers. CRC
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00f\x00\x02\x04\xff\xff\xff\xfb' + 'u\xfa'] = '\x01\x10' + '\x00f\x00\x02' + '\xa1\xd7'
 
-# Write long (2 registers, starting at 102) on slave 1 using function code 16, with value 3. #
+# Write long (2 registers, starting at 102) on subordinate 1 using function code 16, with value 3. #
 # -------------------------------------------------------------------------------------------#
-# Message: Slave address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=3. CRC.
-# Response: Slave address 1, function code 16. Register address 102, 2 registers. CRC
+# Message: Subordinate address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=3. CRC.
+# Response: Subordinate address 1, function code 16. Register address 102, 2 registers. CRC
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00f\x00\x02\x04\x00\x00\x00\x03' + '5\xac'] = '\x01\x10' + '\x00f\x00\x02' + '\xa1\xd7'
 
-# Write long (2 registers, starting at 102) on slave 1 using function code 16, with value -3. #
+# Write long (2 registers, starting at 102) on subordinate 1 using function code 16, with value -3. #
 # --------------------------------------------------------------------------------------------#
-# Message: Slave address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=-3. CRC.
-# Response: Slave address 1, function code 16. Register address 102, 2 registers. CRC
+# Message: Subordinate address 1, function code 16. Register address 102, 2 registers, 4 bytes, value=-3. CRC.
+# Response: Subordinate address 1, function code 16. Register address 102, 2 registers. CRC
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00f\x00\x02\x04\xff\xff\xff\xfd' + '\xf5\xf8'] = '\x01\x10' + '\x00f\x00\x02' + '\xa1\xd7'
 
 
 #                ##  READ FLOAT ##
 
-# Read float from address 103 (2 registers) on slave 1 using function code 3 #
+# Read float from address 103 (2 registers) on subordinate 1 using function code 3 #
 # ---------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 103, 2 registers. CRC.
-# Response: Slave address 1, function code 3. 4 bytes, value=1.0. CRC.
+# Message:  Subordinate address 1, function code 3. Register address 103, 2 registers. CRC.
+# Response: Subordinate address 1, function code 3. 4 bytes, value=1.0. CRC.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00g\x00\x02' + 'u\xd4'] = '\x01\x03' + '\x04\x3f\x80\x00\x00' + '\xf7\xcf'
 
-# Read float from address 103 (2 registers) on slave 1 using function code 4 #
+# Read float from address 103 (2 registers) on subordinate 1 using function code 4 #
 # ---------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 4. Register address 103, 2 registers. CRC.
-# Response: Slave address 1, function code 4. 4 bytes, value=3.65e30. CRC.
+# Message:  Subordinate address 1, function code 4. Register address 103, 2 registers. CRC.
+# Response: Subordinate address 1, function code 4. 4 bytes, value=3.65e30. CRC.
 GOOD_RTU_RESPONSES['\x01\x04' + '\x00g\x00\x02' + '\xc0\x14'] = '\x01\x04' + '\x04\x72\x38\x47\x25' + '\x93\x1a'
 
-# Read float from address 103 (4 registers) on slave 1 using function code 3 #
+# Read float from address 103 (4 registers) on subordinate 1 using function code 3 #
 # ---------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 103, 4 registers. CRC.
-# Response: Slave address 1, function code 3. 8 bytes, value=-2.0 CRC.
+# Message:  Subordinate address 1, function code 3. Register address 103, 4 registers. CRC.
+# Response: Subordinate address 1, function code 3. 8 bytes, value=-2.0 CRC.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00g\x00\x04' + '\xf5\xd6'] = '\x01\x03' + '\x08\xc0\x00\x00\x00\x00\x00\x00\x00' + '\x99\x87'
 
 
 #                ##  WRITE FLOAT ##
 
-# Write float 1.1 to address 103 (2 registers) on slave 1 using function code 16 #
+# Write float 1.1 to address 103 (2 registers) on subordinate 1 using function code 16 #
 # -------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 103, 2 registers, 4 bytes, value=1.1 . CRC.
-# Response: Slave address 1, function code 16. Register address 103, 2 registers. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 103, 2 registers, 4 bytes, value=1.1 . CRC.
+# Response: Subordinate address 1, function code 16. Register address 103, 2 registers. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00g\x00\x02\x04?\x8c\xcc\xcd' + '\xed\x0b'] = '\x01\x10' + '\x00g\x00\x02' + '\xf0\x17'
 
-# Write float 1.1 to address 103 (4 registers) on slave 1 using function code 16 #
+# Write float 1.1 to address 103 (4 registers) on subordinate 1 using function code 16 #
 # -------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 103, 4 registers, 8 bytes, value=1.1 . CRC.
-# Response: Slave address 1, function code 16. Register address 103, 4 registers. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 103, 4 registers, 8 bytes, value=1.1 . CRC.
+# Response: Subordinate address 1, function code 16. Register address 103, 4 registers. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00g\x00\x04\x08?\xf1\x99\x99\x99\x99\x99\x9a' + 'u\xf7'] = '\x01\x10' + '\x00g\x00\x04' + 'p\x15'
 
 
 #                ##  READ STRING  ##
 
-# Read string from address 104 (1 register) on slave 1 using function code 3 #
+# Read string from address 104 (1 register) on subordinate 1 using function code 3 #
 # ---------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 104, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes, value = 'AB'.  CRC.
+# Message:  Subordinate address 1, function code 3. Register address 104, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes, value = 'AB'.  CRC.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00h\x00\x01' + '\x05\xd6'] = '\x01\x03' + '\x02AB' + '\x08%'
 
-# Read string from address 104 (4 registers) on slave 1 using function code 3 #
+# Read string from address 104 (4 registers) on subordinate 1 using function code 3 #
 # ----------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 104, 4 registers. CRC.
-# Response: Slave address 1, function code 3.  8 bytes, value = 'ABCDEFGH'.  CRC.
+# Message:  Subordinate address 1, function code 3. Register address 104, 4 registers. CRC.
+# Response: Subordinate address 1, function code 3.  8 bytes, value = 'ABCDEFGH'.  CRC.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00h\x00\x04' + '\xc5\xd5'] = '\x01\x03' + '\x08ABCDEFGH' + '\x0b\xcc'
 
 
 #                ##  WRITE STRING  ##
 
-# Write string 'A' to address 104 (1 register) on slave 1 using function code 16 #
+# Write string 'A' to address 104 (1 register) on subordinate 1 using function code 16 #
 # -------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 104, 1 register, 2 bytes, value='A ' . CRC.
-# Response: Slave address 1, function code 16. Register address 104, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 104, 1 register, 2 bytes, value='A ' . CRC.
+# Response: Subordinate address 1, function code 16. Register address 104, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00h\x00\x01\x02A ' + '\x9f0'] = '\x01\x10' + '\x00h\x00\x01' + '\x80\x15'
 
-# Write string 'A' to address 104 (4 registers) on slave 1 using function code 16 #
+# Write string 'A' to address 104 (4 registers) on subordinate 1 using function code 16 #
 # --------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 104, 4 registers, 8 bytes, value='A       ' . CRC.
-# Response: Slave address 1, function code 16. Register address 104, 2 registers. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 104, 4 registers, 8 bytes, value='A       ' . CRC.
+# Response: Subordinate address 1, function code 16. Register address 104, 2 registers. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00h\x00\x04\x08A       ' + '\xa7\xae'] = '\x01\x10' + '\x00h\x00\x04' + '@\x16'
 
-# Write string 'ABCDEFGH' to address 104 (4 registers) on slave 1 using function code 16 #
+# Write string 'ABCDEFGH' to address 104 (4 registers) on subordinate 1 using function code 16 #
 # ---------------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 104, 4 registers, 8 bytes, value='ABCDEFGH' . CRC.
-# Response: Slave address 1, function code 16. Register address 104, 4 registers. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 104, 4 registers, 8 bytes, value='ABCDEFGH' . CRC.
+# Response: Subordinate address 1, function code 16. Register address 104, 4 registers. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00h\x00\x04\x08ABCDEFGH' + 'I>'] = '\x01\x10' + '\x00h\x00\x04' + '@\x16'
 
 
 #                ##  READ REGISTERS  ##
 
-# Read from address 105 (1 register) on slave 1 using function code 3 #
+# Read from address 105 (1 register) on subordinate 1 using function code 3 #
 # --------------------------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 105, 1 register. CRC.
-# Response: Slave address 1, function code 3. 2 bytes, value = 16.  CRC.
+# Message:  Subordinate address 1, function code 3. Register address 105, 1 register. CRC.
+# Response: Subordinate address 1, function code 3. 2 bytes, value = 16.  CRC.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00i\x00\x01' + 'T\x16'] = '\x01\x03' + '\x02\x00\x10' + '\xb9\x88'
 
-# Read from address 105 (3 registers) on slave 1 using function code 3 #
+# Read from address 105 (3 registers) on subordinate 1 using function code 3 #
 # ---------------------------------------------------------------------#
-# Message:  Slave address 1, function code 3. Register address 105, 3 registers. CRC.
-# Response: Slave address 1, function code 3. 6 bytes, value = 16, 32, 64. CRC.
+# Message:  Subordinate address 1, function code 3. Register address 105, 3 registers. CRC.
+# Response: Subordinate address 1, function code 3. 6 bytes, value = 16, 32, 64. CRC.
 GOOD_RTU_RESPONSES['\x01\x03' + '\x00i\x00\x03' + '\xd5\xd7'] =  '\x01\x03' + '\x06\x00\x10\x00\x20\x00\x40' + '\xe0\x8c'
 
 
 #                ##  WRITE REGISTERS  ##
 
-# Write value [2] to address 105 (1 register) on slave 1 using function code 16 #
+# Write value [2] to address 105 (1 register) on subordinate 1 using function code 16 #
 # ------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 105, 1 register, 2 bytes, value=2 . CRC.
-# Response: Slave address 1, function code 16. Register address 105, 1 register. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 105, 1 register, 2 bytes, value=2 . CRC.
+# Response: Subordinate address 1, function code 16. Register address 105, 1 register. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00i\x00\x01\x02\x00\x02' + '.\xa8'] = '\x01\x10' + '\x00i\x00\x01' + '\xd1\xd5'
 
-# Write value [2, 4, 8] to address 105 (3 registers) on slave 1 using function code 16 #
+# Write value [2, 4, 8] to address 105 (3 registers) on subordinate 1 using function code 16 #
 # -------------------------------------------------------------------------------------#
-# Message:  Slave address 1, function code 16. Register address 105, 3 register, 6 bytes, value=2, 4, 8. CRC.
-# Response: Slave address 1, function code 16. Register address 105, 3 registers. CRC.
+# Message:  Subordinate address 1, function code 16. Register address 105, 3 register, 6 bytes, value=2, 4, 8. CRC.
+# Response: Subordinate address 1, function code 16. Register address 105, 3 registers. CRC.
 GOOD_RTU_RESPONSES['\x01\x10' + '\x00i\x00\x03\x06\x00\x02\x00\x04\x00\x08' + '\x0c\xd6'] = '\x01\x10' + '\x00i\x00\x03' + 'P\x14'
 
 
@@ -2660,57 +2660,57 @@ WRONG_RTU_RESPONSES['TESTMESSAGE'] = 'TESTRESPONSE'
 # ---------------------------------------------------------------- #
 WRONG_RTU_RESPONSES['\x01\x10TESTCOMMAND\x08B']     = '\x01\x10TESTCOMMANDRESPONSE\xb4,'
 WRONG_RTU_RESPONSES['\x01\x4bTESTCOMMAND2\x18\xc8'] = '\x01\x4bTESTCOMMANDRESPONSE2K\x8c'
-WRONG_RTU_RESPONSES['\x01\x01TESTCOMMAND4~']        = '\x02\x01TESTCOMMANDRESPONSEx]'    # Wrong slave address in response
+WRONG_RTU_RESPONSES['\x01\x01TESTCOMMAND4~']        = '\x02\x01TESTCOMMANDRESPONSEx]'    # Wrong subordinate address in response
 WRONG_RTU_RESPONSES['\x01\x02TESTCOMMAND0z']        = '\x01\x03TESTCOMMANDRESPONSE2\x8c' # Wrong function code in response
 WRONG_RTU_RESPONSES['\x01\x03TESTCOMMAND\xcd\xb9']  = '\x01\x03TESTCOMMANDRESPONSEab'    # Wrong CRC in response
 WRONG_RTU_RESPONSES['\x01\x04TESTCOMMAND8r']        = 'A'                                # Too short response message
-WRONG_RTU_RESPONSES['\x01\x05TESTCOMMAND\xc5\xb1']  = '\x01\x85TESTCOMMANDRESPONSE\xa54' # Error indication from slave
+WRONG_RTU_RESPONSES['\x01\x05TESTCOMMAND\xc5\xb1']  = '\x01\x85TESTCOMMANDRESPONSE\xa54' # Error indication from subordinate
 
 
 ## Recorded data from OmegaCN7500 ##
 ####################################
-# (Sorted by slave address, register address)
+# (Sorted by subordinate address, register address)
 
-# Slave address 1, read_bit(2068) Response value 1.
+# Subordinate address 1, read_bit(2068) Response value 1.
 GOOD_RTU_RESPONSES['\x01\x02\x08\x14\x00\x01\xfb\xae'] ='\x01\x02\x01\x01`H'
 
-# Slave address 1, write_bit(2068, 0)
+# Subordinate address 1, write_bit(2068, 0)
 GOOD_RTU_RESPONSES['\x01\x05\x08\x14\x00\x00\x8f\xae'] ='\x01\x05\x08\x14\x00\x00\x8f\xae'
 
-# Slave address 1, write_bit(2068, 1)
+# Subordinate address 1, write_bit(2068, 1)
 GOOD_RTU_RESPONSES['\x01\x05\x08\x14\xff\x00\xce^'] ='\x01\x05\x08\x14\xff\x00\xce^'
 
-# Slave address 1, read_register(4097, 1) Response value 823.6
+# Subordinate address 1, read_register(4097, 1) Response value 823.6
 GOOD_RTU_RESPONSES['\x01\x03\x10\x01\x00\x01\xd1\n'] ='\x01\x03\x02 ,\xa0Y'
 
-# Slave address 1, write_register(4097, 700.0, 1)
+# Subordinate address 1, write_register(4097, 700.0, 1)
 GOOD_RTU_RESPONSES['\x01\x10\x10\x01\x00\x01\x02\x1bX\xbdJ'] ='\x01\x10\x10\x01\x00\x01T\xc9'
 
-# Slave address 1, write_register(4097, 823.6, 1)
+# Subordinate address 1, write_register(4097, 823.6, 1)
 GOOD_RTU_RESPONSES['\x01\x10\x10\x01\x00\x01\x02 ,\xae]'] ='\x01\x10\x10\x01\x00\x01T\xc9'
 
-# Slave address 10, read_bit(2068) Response value 1
+# Subordinate address 10, read_bit(2068) Response value 1
 GOOD_RTU_RESPONSES['\n\x02\x08\x14\x00\x01\xfa\xd5'] = '\n\x02\x01\x01bl'
 
-# Slave address 10, write_bit(2068, 0)
+# Subordinate address 10, write_bit(2068, 0)
 GOOD_RTU_RESPONSES['\n\x05\x08\x14\x00\x00\x8e\xd5'] ='\n\x05\x08\x14\x00\x00\x8e\xd5'
 
-# Slave address 10, write_bit(2068, 1)
+# Subordinate address 10, write_bit(2068, 1)
 GOOD_RTU_RESPONSES['\n\x05\x08\x14\xff\x00\xcf%'] ='\n\x05\x08\x14\xff\x00\xcf%'
 
-# Slave address 10, read_register(4096, 1) Response value 25.0
+# Subordinate address 10, read_register(4096, 1) Response value 25.0
 GOOD_RTU_RESPONSES['\n\x03\x10\x00\x00\x01\x81\xb1'] ='\n\x03\x02\x00\xfa\x9d\xc6'
 
-# Slave address 10, read_register(4097, 1) Response value 325.8
+# Subordinate address 10, read_register(4097, 1) Response value 325.8
 GOOD_RTU_RESPONSES['\n\x03\x10\x01\x00\x01\xd0q'] ='\n\x03\x02\x0c\xba\x996'
 
-# Slave address 10, write_register(4097, 325.8, 1)
+# Subordinate address 10, write_register(4097, 325.8, 1)
 GOOD_RTU_RESPONSES['\n\x10\x10\x01\x00\x01\x02\x0c\xbaA\xc3'] ='\n\x10\x10\x01\x00\x01U\xb2'
 
-# Slave address 10, write_register(4097, 20.0, 1)
+# Subordinate address 10, write_register(4097, 20.0, 1)
 GOOD_RTU_RESPONSES['\n\x10\x10\x01\x00\x01\x02\x00\xc8\xc4\xe6'] ='\n\x10\x10\x01\x00\x01U\xb2'
 
-# Slave address 10, write_register(4097, 200.0, 1)
+# Subordinate address 10, write_register(4097, 200.0, 1)
 GOOD_RTU_RESPONSES['\n\x10\x10\x01\x00\x01\x02\x07\xd0\xc6\xdc'] ='\n\x10\x10\x01\x00\x01U\xb2'
 
 
@@ -2718,87 +2718,87 @@ GOOD_RTU_RESPONSES['\n\x10\x10\x01\x00\x01\x02\x07\xd0\xc6\xdc'] ='\n\x10\x10\x0
 ##########################################
 # (Sorted by register number)
 
-# Slave address 7, read_bit(0x0800). This is LED AT.
+# Subordinate address 7, read_bit(0x0800). This is LED AT.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x02\x08\x00\x00\x01\xbb\xcc'] = '\x07\x02\x01\x00\xa1\x00'
     
-# Slave address 7, read_bit(0x0801). This is LED Out1.
+# Subordinate address 7, read_bit(0x0801). This is LED Out1.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x02\x08\x01\x00\x01\xea\x0c'] = '\x07\x02\x01\x00\xa1\x00' 
 
-# Slave address 7, read_bit(0x0802). This is LED Out2.
+# Subordinate address 7, read_bit(0x0802). This is LED Out2.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x02\x08\x02\x00\x01\x1a\x0c'] = '\x07\x02\x01\x00\xa1\x00' 
 
-# Slave address 7, write_bit(0x0810, 1) This is "Communication write in enabled".
+# Subordinate address 7, write_bit(0x0810, 1) This is "Communication write in enabled".
 GOOD_RTU_RESPONSES['\x07\x05\x08\x10\xff\x00\x8f\xf9'] = '\x07\x05\x08\x10\xff\x00\x8f\xf9'
 
-# Slave address 7, _performCommand(2, '\x08\x10\x00\x09'). This is reading 9 bits starting at 0x0810.
+# Subordinate address 7, _performCommand(2, '\x08\x10\x00\x09'). This is reading 9 bits starting at 0x0810.
 # Response value '\x02\x07\x00'
 GOOD_RTU_RESPONSES['\x07\x02\x08\x10\x00\t\xbb\xcf'] = '\x07\x02\x02\x07\x003\x88'
 
-# Slave address 7, read_bit(0x0814). This is RUN/STOP setting.
+# Subordinate address 7, read_bit(0x0814). This is RUN/STOP setting.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x02\x08\x14\x00\x01\xfb\xc8'] = '\x07\x02\x01\x00\xa1\x00'
 
-# Slave address 7, write_bit(0x0814, 0). This is STOP.
+# Subordinate address 7, write_bit(0x0814, 0). This is STOP.
 GOOD_RTU_RESPONSES['\x07\x05\x08\x14\x00\x00\x8f\xc8'] = '\x07\x05\x08\x14\x00\x00\x8f\xc8'
 
-# Slave address 7, write_bit(0x0814, 1). This is RUN.
+# Subordinate address 7, write_bit(0x0814, 1). This is RUN.
 GOOD_RTU_RESPONSES['\x07\x05\x08\x14\xff\x00\xce8'] = '\x07\x05\x08\x14\xff\x00\xce8'
 
-# Slave address 7, read_registers(0x1000, 2). This is process value (PV) and setpoint (SV).
+# Subordinate address 7, read_registers(0x1000, 2). This is process value (PV) and setpoint (SV).
 # Response value [64990, 350]
 GOOD_RTU_RESPONSES['\x07\x03\x10\x00\x00\x02\xc0\xad'] = '\x07\x03\x04\xfd\xde\x01^M\xcd'
 
-# Slave address 7, read_register(0x1000). This is process value (PV).
+# Subordinate address 7, read_register(0x1000). This is process value (PV).
 # Response value 64990
 GOOD_RTU_RESPONSES['\x07\x03\x10\x00\x00\x01\x80\xac'] = '\x07\x03\x02\xfd\xde\xf0\x8c'
 
-# Slave address 7, read_register(0x1001, 1). This is setpoint (SV).
+# Subordinate address 7, read_register(0x1001, 1). This is setpoint (SV).
 # Response value 80.0
 GOOD_RTU_RESPONSES['\x07\x03\x10\x01\x00\x01\xd1l'] = '\x07\x03\x02\x03 1l'
 
-# Slave address 7, write_register(0x1001, 25, 1, functioncode=6)
+# Subordinate address 7, write_register(0x1001, 25, 1, functioncode=6)
 GOOD_RTU_RESPONSES['\x07\x06\x10\x01\x00\xfa\\\xef'] = '\x07\x06\x10\x01\x00\xfa\\\xef'
 
-# Slave address 7, write_register(0x1001, 0x0320, functioncode=6) # Write value 800 to register 0x1001.
+# Subordinate address 7, write_register(0x1001, 0x0320, functioncode=6) # Write value 800 to register 0x1001.
 # This is a setpoint of 80.0 degrees (Centigrades, dependent on setting).
 GOOD_RTU_RESPONSES['\x07\x06\x10\x01\x03 \xdd\x84'] = '\x07\x06\x10\x01\x03 \xdd\x84'
 
-# Slave address 7, read_register(0x1004). This is sensor type.
+# Subordinate address 7, read_register(0x1004). This is sensor type.
 # Response value 14
 GOOD_RTU_RESPONSES['\x07\x03\x10\x04\x00\x01\xc1m'] = '\x07\x03\x02\x00\x0e\xb1\x80'   
 
-# Slave address 7, read_register(0x1005) This is control method.
+# Subordinate address 7, read_register(0x1005) This is control method.
 # Response value 1
 GOOD_RTU_RESPONSES['\x07\x03\x10\x05\x00\x01\x90\xad'] = '\x07\x03\x02\x00\x01\xf1\x84'   
 
-# Slave address 7, read_register(0x1006). This is heating/cooling selection.
+# Subordinate address 7, read_register(0x1006). This is heating/cooling selection.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x03\x10\x06\x00\x01`\xad'] = '\x07\x03\x02\x00\x000D' 
     
-# Slave address 7, read_register(0x1012, 1). This is output 1.    
+# Subordinate address 7, read_register(0x1012, 1). This is output 1.    
 # Response value 0.0
 GOOD_RTU_RESPONSES['\x07\x03\x10\x12\x00\x01 \xa9'] = '\x07\x03\x02\x00\x000D'
 
-# Slave address 7, read_register(0x1013, 1). This is output 2.    
+# Subordinate address 7, read_register(0x1013, 1). This is output 2.    
 # Response value 0.0
 GOOD_RTU_RESPONSES['\x07\x03\x10\x13\x00\x01qi'] = '\x07\x03\x02\x00\x000D'
 
-# Slave address 7, read_register(0x1023). This is system alarm setting.
+# Subordinate address 7, read_register(0x1023). This is system alarm setting.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x03\x10#\x00\x01qf'] = '\x07\x03\x02\x00\x000D'
 
-# Slave address 7, read_register(0x102A). This is LED status.
+# Subordinate address 7, read_register(0x102A). This is LED status.
 # Response value 0
 GOOD_RTU_RESPONSES['\x07\x03\x10*\x00\x01\xa1d'] = '\x07\x03\x02\x00\x000D'
 
-# Slave address 7, read_register(0x102B). This is pushbutton status.
+# Subordinate address 7, read_register(0x102B). This is pushbutton status.
 # Response value 15
 GOOD_RTU_RESPONSES['\x07\x03\x10+\x00\x01\xf0\xa4'] = '\x07\x03\x02\x00\x0fp@'
 
-# Slave address 7, read_register(0x102F). This is firmware version.
+# Subordinate address 7, read_register(0x102F). This is firmware version.
 # Response value 400
 GOOD_RTU_RESPONSES['\x07\x03\x10/\x00\x01\xb1e'] = '\x07\x03\x02\x01\x901\xb8'
 
@@ -2807,87 +2807,87 @@ GOOD_RTU_RESPONSES['\x07\x03\x10/\x00\x01\xb1e'] = '\x07\x03\x02\x01\x901\xb8'
 ############################################
 # (Sorted by register number)
 
-# Slave address 7, read_bit(0x0800). This is LED AT.
+# Subordinate address 7, read_bit(0x0800). This is LED AT.
 # Response value 0
 GOOD_ASCII_RESPONSES[':070208000001EE\r\n'] = ':07020100F6\r\n'
 
-# Slave address 7, read_bit(0x0801). This is LED Out1.
+# Subordinate address 7, read_bit(0x0801). This is LED Out1.
 # Response value 1
 GOOD_ASCII_RESPONSES[':070208010001ED\r\n'] = ':07020101F5\r\n' 
 
-# Slave address 7, read_bit(0x0802). This is LED Out2.
+# Subordinate address 7, read_bit(0x0802). This is LED Out2.
 # Response value 0
 GOOD_ASCII_RESPONSES[':070208020001EC\r\n'] = ':07020100F6\r\n'
 
-# Slave address 7, _performCommand(2, '\x08\x10\x00\x09'). This is reading 9 bits starting at 0x0810.
+# Subordinate address 7, _performCommand(2, '\x08\x10\x00\x09'). This is reading 9 bits starting at 0x0810.
 # Response value '\x02\x17\x00'
 GOOD_ASCII_RESPONSES[':070208100009D6\r\n'] = ':0702021700DE\r\n'
 
-# Slave address 7, write_bit(0x0810, 1) This is "Communication write in enabled".
+# Subordinate address 7, write_bit(0x0810, 1) This is "Communication write in enabled".
 GOOD_ASCII_RESPONSES[':07050810FF00DD\r\n'] = ':07050810FF00DD\r\n'
 
-# Slave address 7, read_bit(0x0814). This is RUN/STOP setting.
+# Subordinate address 7, read_bit(0x0814). This is RUN/STOP setting.
 # Response value 1
 GOOD_ASCII_RESPONSES[':070208140001DA\r\n'] = ':07020101F5\r\n'
 
-# Slave address 7, write_bit(0x0814, 0). This is STOP.
+# Subordinate address 7, write_bit(0x0814, 0). This is STOP.
 GOOD_ASCII_RESPONSES[':070508140000D8\r\n'] = ':070508140000D8\r\n'
 
-# Slave address 7, write_bit(0x0814, 1). This is RUN.
+# Subordinate address 7, write_bit(0x0814, 1). This is RUN.
 GOOD_ASCII_RESPONSES[':07050814FF00D9\r\n'] = ':07050814FF00D9\r\n'
 
-# Slave address 7, read_registers(0x1000, 2). This is process value (PV) and setpoint (SV).
+# Subordinate address 7, read_registers(0x1000, 2). This is process value (PV) and setpoint (SV).
 # Response value [64990, 350]
 GOOD_ASCII_RESPONSES[':070310000002E4\r\n'] = ':070304FDDE015EB8\r\n'
 
-# Slave address 7, read_register(0x1000). This is process value (PV).
+# Subordinate address 7, read_register(0x1000). This is process value (PV).
 # Response value 64990
 GOOD_ASCII_RESPONSES[':070310000001E5\r\n'] = ':070302FDDE19\r\n'
 
-# Slave address 7, read_register(0x1001, 1). This is setpoint (SV).
+# Subordinate address 7, read_register(0x1001, 1). This is setpoint (SV).
 # Response value 80.0
 GOOD_ASCII_RESPONSES[':070310010001E4\r\n'] = ':0703020320D1\r\n'
 
-# Slave address 7, write_register(0x1001, 25, 1, functioncode=6)
+# Subordinate address 7, write_register(0x1001, 25, 1, functioncode=6)
 GOOD_ASCII_RESPONSES[':0706100100FAE8\r\n'] = ':0706100100FAE8\r\n'
 
-# Slave address 7, write_register(0x1001, 0x0320, functioncode=6) # Write value 800 to register 0x1001.
+# Subordinate address 7, write_register(0x1001, 0x0320, functioncode=6) # Write value 800 to register 0x1001.
 # This is a setpoint of 80.0 degrees (Centigrades, dependent on setting).
 GOOD_ASCII_RESPONSES[':070610010320BF\r\n'] = ':070610010320BF\r\n'
 
-# Slave address 7, read_register(0x1004). This is sensor type.
+# Subordinate address 7, read_register(0x1004). This is sensor type.
 # Response value 14
 GOOD_ASCII_RESPONSES[':070310040001E1\r\n'] = ':070302000EE6\r\n'
 
-# Slave address 7, read_register(0x1005) This is control method.
+# Subordinate address 7, read_register(0x1005) This is control method.
 # Response value 1
 GOOD_ASCII_RESPONSES[':070310050001E0\r\n'] = ':0703020001F3\r\n'
 
-# Slave address 7, read_register(0x1006). This is heating/cooling selection.
+# Subordinate address 7, read_register(0x1006). This is heating/cooling selection.
 # Response value 0
 GOOD_ASCII_RESPONSES[':070310060001DF\r\n'] = ':0703020000F4\r\n'
 
-# Slave address 7, read_register(0x1012, 1). This is output 1.    
+# Subordinate address 7, read_register(0x1012, 1). This is output 1.    
 # Response value 100.0
 GOOD_ASCII_RESPONSES[':070310120001D3\r\n'] = ':07030203E809\r\n'
 
-# Slave address 7, read_register(0x1013, 1). This is output 2.    
+# Subordinate address 7, read_register(0x1013, 1). This is output 2.    
 # Response value 0.0
 GOOD_ASCII_RESPONSES[':070310130001D2\r\n'] = ':0703020000F4\r\n'
 
-# Slave address 7, read_register(0x1023). This is system alarm setting.
+# Subordinate address 7, read_register(0x1023). This is system alarm setting.
 # Response value 0
 GOOD_ASCII_RESPONSES[':070310230001C2\r\n'] = ':0703020000F4\r\n'
 
-# Slave address 7, read_register(0x102A). This is LED status.
+# Subordinate address 7, read_register(0x102A). This is LED status.
 # Response value 64
 GOOD_ASCII_RESPONSES[':0703102A0001BB\r\n'] = ':0703020040B4\r\n'
 
-# Slave address 7, read_register(0x102B). This is pushbutton status.
+# Subordinate address 7, read_register(0x102B). This is pushbutton status.
 # Response value 15
 GOOD_ASCII_RESPONSES[':0703102B0001BA\r\n'] = ':070302000FE5\r\n'
 
-# Slave address 7, read_register(0x102F). This is firmware version.
+# Subordinate address 7, read_register(0x102F). This is firmware version.
 # Response value 400
 GOOD_ASCII_RESPONSES[':0703102F0001B6\r\n'] = ':070302019063\r\n'
 

--- a/rs485/MinimalModbus-0.6/test/test_omegacn7500.py
+++ b/rs485/MinimalModbus-0.6/test/test_omegacn7500.py
@@ -178,8 +178,8 @@ class TestCheckTimeValue(unittest.TestCase):
 # Communication using a dummy serial port #
 ###########################################
 
-class TestDummyCommunication_Slave1(unittest.TestCase):
-    """Testing using dummy communication, with data recorded for slaveaddress = 1
+class TestDummyCommunication_Subordinate1(unittest.TestCase):
+    """Testing using dummy communication, with data recorded for subordinateaddress = 1
     
     Most of the tests are for making sure that the communication details are OK.
     
@@ -277,7 +277,7 @@ class TestDummyCommunication_Slave1(unittest.TestCase):
         self.instrument.set_pattern_link_topattern(0, 1)
         
     def testGetAllPatternVariables(self):  # TODO: Change this to proper assertEqual   
-        _print_out( '\nSlave address 1:' )     
+        _print_out( '\nSubordinate address 1:' )     
         _print_out( self.instrument.get_all_pattern_variables(0) )
 
     def testSetAllPatternVariables(self):       
@@ -293,8 +293,8 @@ class TestDummyCommunication_Slave1(unittest.TestCase):
             7, 4, 1)         
 
 
-class TestDummyCommunication_Slave10(unittest.TestCase):
-    """Testing using dummy communication, with data recorded for slaveaddress = 10
+class TestDummyCommunication_Subordinate10(unittest.TestCase):
+    """Testing using dummy communication, with data recorded for subordinateaddress = 10
 
     """
 
@@ -368,7 +368,7 @@ class TestDummyCommunication_Slave10(unittest.TestCase):
         self.instrument.set_pattern_link_topattern(0, 1)
     
     def testGetAllPatternVariables(self):   # TODO: Change this to proper assertEqual
-        _print_out( '\nSlave address 10:' )     
+        _print_out( '\nSubordinate address 10:' )     
         _print_out( self.instrument.get_all_pattern_variables(0) )
         
         
@@ -396,47 +396,47 @@ from the dummy serial port.
 ## Recorded data from OmegaCN7500 ##
 ####################################
 
-# Slave address 1, get_pv()
+# Subordinate address 1, get_pv()
 RESPONSES['\x01\x03\x10\x00\x00\x01\x80\xca'] = '\x01\x03\x02\x00\xf68\x02'
 
-# Slave address 1, run()
+# Subordinate address 1, run()
 RESPONSES['\x01\x05\x08\x14\xff\x00\xce^'] = '\x01\x05\x08\x14\xff\x00\xce^'
     
-# Slave address 1, stop()
+# Subordinate address 1, stop()
 RESPONSES['\x01\x05\x08\x14\x00\x00\x8f\xae'] = '\x01\x05\x08\x14\x00\x00\x8f\xae'
     
-# Slave address 1, is_running()
+# Subordinate address 1, is_running()
 RESPONSES['\x01\x02\x08\x14\x00\x01\xfb\xae'] = '\x01\x02\x01\x00\xa1\x88'
    
-# Slave address 1, get_setpoint()
+# Subordinate address 1, get_setpoint()
 RESPONSES['\x01\x03\x10\x01\x00\x01\xd1\n'] = '\x01\x03\x02\x03\xe8\xb8\xfa'
     
-# Slave address 1, set_setpoint()    
+# Subordinate address 1, set_setpoint()    
 RESPONSES['\x01\x10\x10\x01\x00\x01\x02\x03\xe8\xb6\xfe'] = '\x01\x10\x10\x01\x00\x01T\xc9'
 
-# Slave address 1, get_control_mode()        
+# Subordinate address 1, get_control_mode()        
 RESPONSES['\x01\x03\x10\x05\x00\x01\x90\xcb'] = '\x01\x03\x02\x00\x00\xb8D'    
 #RESPONSES['\x01\x03\x10\x05\x00\x01\x90\xcb'] = '\x01\x03\x02\x00\x09xB'  # Use this for testing wrong controlmode
 
-# Slave address 1, set_control_mode()  
+# Subordinate address 1, set_control_mode()  
 RESPONSES['\x01\x10\x10\x05\x00\x01\x02\x00\x03\xf7\xc5'] = '\x01\x10\x10\x05\x00\x01\x15\x08'
 
-# Slave address 1, get_start_pattern_no()
+# Subordinate address 1, get_start_pattern_no()
 RESPONSES['\x01\x03\x100\x00\x01\x80\xc5'] = '\x01\x03\x02\x00\x029\x85'
 
-# Slave address 1, set_start_pattern_no()
+# Subordinate address 1, set_start_pattern_no()
 RESPONSES['\x01\x10\x100\x00\x01\x02\x00\x023\xa0'] = '\x01\x10\x100\x00\x01\x05\x06'
 
-# Slave address 1, set_pattern_step_setpoint() Pattern 0, step 3, value 333.3. See also below. 
+# Subordinate address 1, set_pattern_step_setpoint() Pattern 0, step 3, value 333.3. See also below. 
 RESPONSES['\x01\x10 \x03\x00\x01\x02\r\x05C2'] = '\x01\x10 \x03\x00\x01\xfa\t'
 
-# Slave address 1, set_pattern_step_time() Pattern 0, step 3, value 45. See also below. 
+# Subordinate address 1, set_pattern_step_time() Pattern 0, step 3, value 45. See also below. 
 RESPONSES['\x01\x10 \x83\x00\x01\x02\x00-X|'] = '\x01\x10 \x83\x00\x01\xfb\xe1'
 
-# Slave address 1, set_pattern_additional_cycles() Pattern 0, value 4. See also below. 
+# Subordinate address 1, set_pattern_additional_cycles() Pattern 0, value 4. See also below. 
 RESPONSES['\x01\x10\x10P\x00\x01\x02\x00\x04\xba\x02'] = '\x01\x10\x10P\x00\x01\x05\x18'
 
-# Slave address 1, get_all_pattern_variables() 
+# Subordinate address 1, get_all_pattern_variables() 
 # --- Valid for pattern 0 ---
 # SP0: 10   Time0: 10 
 # SP1: 20   Time1: 20
@@ -471,7 +471,7 @@ RESPONSES['\x01\x03\x10@\x00\x01\x81\x1e'] = '\x01\x03\x02\x00\x07\xf9\x86' # Ac
 RESPONSES['\x01\x03\x10P\x00\x01\x80\xdb'] = '\x01\x03\x02\x00\x04\xb9\x87' # Cycles
 RESPONSES['\x01\x03\x10`\x00\x01\x80\xd4'] = '\x01\x03\x02\x00\x01y\x84'    # Linked pattern
 
-# Slave address 1, set_all_pattern_variables()
+# Subordinate address 1, set_all_pattern_variables()
 # --- Valid for pattern 0 ---
 RESPONSES['\x01\x10 \x00\x00\x01\x02\x00d\x86y']       = '\x01\x10 \x00\x00\x01\n\t'     # SP0
 RESPONSES['\x01\x10 \x01\x00\x01\x02\x00\xc8\x87\xd5'] = '\x01\x10 \x01\x00\x01[\xc9'
@@ -495,46 +495,46 @@ RESPONSES['\x01\x10\x10@\x00\x01\x02\x00\x07\xf8\x93'] = '\x01\x10\x10@\x00\x01\
 RESPONSES['\x01\x10\x10P\x00\x01\x02\x00\x02:\x00']    = '\x01\x10\x10P\x00\x01\x05\x18' # Cycles, value 2
 RESPONSES['\x01\x10\x10`\x00\x01\x02\x00\x01\x7f\xf1'] = '\x01\x10\x10`\x00\x01\x05\x17' # Linked pattern
 
-# Slave address 10, get_pv()
+# Subordinate address 10, get_pv()
 RESPONSES['\n\x03\x10\x00\x00\x01\x81\xb1'] = '\n\x03\x02\x01\x03\\\x14'
 
-# Slave address 10, run()
+# Subordinate address 10, run()
 RESPONSES['\n\x05\x08\x14\xff\x00\xcf%'] = '\n\x05\x08\x14\xff\x00\xcf%'
     
-# Slave address 10, stop()
+# Subordinate address 10, stop()
 RESPONSES['\n\x05\x08\x14\x00\x00\x8e\xd5'] = '\n\x05\x08\x14\x00\x00\x8e\xd5'
     
-# Slave address 10, is_running()
+# Subordinate address 10, is_running()
 RESPONSES['\n\x02\x08\x14\x00\x01\xfa\xd5'] = '\n\x02\x01\x00\xa3\xac'   
     
-# Slave address 10, get_setpoint()
+# Subordinate address 10, get_setpoint()
 RESPONSES['\n\x03\x10\x01\x00\x01\xd0q'] = '\n\x03\x02\x03\xe8\x1d;'
     
-# Slave address 10, set_setpoint()    
+# Subordinate address 10, set_setpoint()    
 RESPONSES['\n\x10\x10\x01\x00\x01\x02\x03\xe8\xc5\xce'] = '\n\x10\x10\x01\x00\x01U\xb2'
 
-# Slave address 10, get_control_mode()        
+# Subordinate address 10, get_control_mode()        
 RESPONSES['\n\x03\x10\x05\x00\x01\x91\xb0'] = '\n\x03\x02\x00\x00\x1d\x85' 
 
-# Slave address 10, set_control_mode()  
+# Subordinate address 10, set_control_mode()  
 RESPONSES['\n\x10\x10\x05\x00\x01\x02\x00\x03\x84\xf5'] = '\n\x10\x10\x05\x00\x01\x14s'
 
-# Slave address 10, get_start_pattern_no()
+# Subordinate address 10, get_start_pattern_no()
 RESPONSES['\n\x03\x100\x00\x01\x81\xbe'] = '\n\x03\x02\x00\x02\x9cD'
 
-# Slave address 10, set_start_pattern_no()
+# Subordinate address 10, set_start_pattern_no()
 RESPONSES['\n\x10\x100\x00\x01\x02\x00\x02@\x90'] = '\n\x10\x100\x00\x01\x04}'
 
-# Slave address 10, set_pattern_step_setpoint() Pattern 0, step 3, value 333.3. See also below. 
+# Subordinate address 10, set_pattern_step_setpoint() Pattern 0, step 3, value 333.3. See also below. 
 RESPONSES['\n\x10 \x03\x00\x01\x02\r\x050\x02'] = '\n\x10 \x03\x00\x01\xfbr'
 
-# Slave address 10, set_pattern_step_time() Pattern 0, step 3, value 45. See also below. 
+# Subordinate address 10, set_pattern_step_time() Pattern 0, step 3, value 45. See also below. 
 RESPONSES['\n\x10 \x83\x00\x01\x02\x00-+L'] = '\n\x10 \x83\x00\x01\xfa\x9a'
 
-# Slave address 10, set_pattern_additional_cycles() Pattern 0, value 4. See also below. 
+# Subordinate address 10, set_pattern_additional_cycles() Pattern 0, value 4. See also below. 
 RESPONSES['\n\x10\x10P\x00\x01\x02\x00\x04\xc92'] = '\n\x10\x10P\x00\x01\x04c'
 
-# Slave address 10, get_all_pattern_variables() 
+# Subordinate address 10, get_all_pattern_variables() 
 # --- Valid for pattern 0 ---
 # SP0: 10   Time0: 10 
 # SP1: 20   Time1: 20
@@ -569,7 +569,7 @@ RESPONSES['\n\x03\x10@\x00\x01\x80e']    = '\n\x03\x02\x00\x07\\G'   # Actual st
 RESPONSES['\n\x03\x10P\x00\x01\x81\xa0'] = '\n\x03\x02\x00\x04\x1cF' # Cycles
 RESPONSES['\n\x03\x10`\x00\x01\x81\xaf'] = '\n\x03\x02\x00\x01\xdcE' # Linked pattern
 
-# Slave address 10, set_all_pattern_variables()
+# Subordinate address 10, set_all_pattern_variables()
 # --- Valid for pattern 0 ---
 RESPONSES['\n\x10 \x00\x00\x01\x02\x00d\xf5I']       = '\n\x10 \x00\x00\x01\x0br'    # SP0
 RESPONSES['\n\x10 \x01\x00\x01\x02\x00\xc8\xf4\xe5'] = '\n\x10 \x01\x00\x01Z\xb2'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.